### PR TITLE
Add support for both Astron and OTP message types

### DIFF
--- a/direct/src/dcparser/dcClass_ext.cxx
+++ b/direct/src/dcparser/dcClass_ext.cxx
@@ -23,6 +23,11 @@
 
 #ifdef HAVE_PYTHON
 
+ConfigVariableBool astron_support
+("astron-support", true,
+ PRC_DESC("Set this true to use the Astron specific message types for messages. "
+          "If this is false, OTP specific messages would be used instead."));
+
 /**
  * Returns true if the DCClass object has an associated Python class
  * definition, false otherwise.
@@ -588,18 +593,35 @@ ai_format_generate(PyObject *distobj, DOID_TYPE do_id,
 
   bool has_optional_fields = (PyObject_IsTrue(optional_fields) != 0);
 
-  if (has_optional_fields) {
-    packer.raw_pack_uint16(STATESERVER_CREATE_OBJECT_WITH_REQUIRED_OTHER);
-  } else {
-    packer.raw_pack_uint16(STATESERVER_CREATE_OBJECT_WITH_REQUIRED);
-  }
+  if (astron_support) {
+    // We want to use Astron's CREATE_OBJECT here.
+    if (has_optional_fields) {
+      packer.raw_pack_uint16(STATESERVER_CREATE_OBJECT_WITH_REQUIRED_OTHER);
+    } else {
+      packer.raw_pack_uint16(STATESERVER_CREATE_OBJECT_WITH_REQUIRED);
+    }
 
-  packer.raw_pack_uint32(do_id);
-  // Parent is a bit overloaded; this parent is not about inheritance, this
-  // one is about the visibility container parent, i.e.  the zone parent:
-  packer.raw_pack_uint32(parent_id);
-  packer.raw_pack_uint32(zone_id);
-  packer.raw_pack_uint16(_this->_number);
+    packer.raw_pack_uint32(do_id);
+    // Parent is a bit overloaded; this parent is not about inheritance, this
+    // one is about the visibility container parent, i.e.  the zone parent:
+    packer.raw_pack_uint32(parent_id);
+    packer.raw_pack_uint32(zone_id);
+    packer.raw_pack_uint16(_this->_number);
+  } else {
+    // Or we want to use OTP's OBJECT_GENERATE instead.
+    if (has_optional_fields) {
+      packer.raw_pack_uint16(STATESERVER_OBJECT_GENERATE_WITH_REQUIRED_OTHER);
+    } else {
+      packer.raw_pack_uint16(STATESERVER_OBJECT_GENERATE_WITH_REQUIRED);
+    }
+
+    // Parent is a bit overloaded; this parent is not about inheritance, this
+    // one is about the visibility container parent, i.e.  the zone parent:
+    packer.raw_pack_uint32(parent_id);
+    packer.raw_pack_uint32(zone_id);
+    packer.raw_pack_uint16(_this->_number);
+    packer.raw_pack_uint32(do_id);
+  }
 
   // Specify all of the required fields.
   int num_fields = _this->get_num_inherited_fields();

--- a/direct/src/dcparser/dcClass_ext.h
+++ b/direct/src/dcparser/dcClass_ext.h
@@ -22,6 +22,9 @@
 #include "dcClass.h"
 #include "py_panda.h"
 
+#include "configVariableBool.h"
+extern ConfigVariableBool astron_support;
+
 /**
  * This class defines the extension methods for DCClass, which are called
  * instead of any C++ methods with the same prototype.

--- a/direct/src/dcparser/dcField_ext.cxx
+++ b/direct/src/dcparser/dcField_ext.cxx
@@ -194,7 +194,11 @@ Datagram Extension<DCField>::
 client_format_update(DOID_TYPE do_id, PyObject *args) const {
   DCPacker packer;
 
-  packer.raw_pack_uint16(CLIENT_OBJECT_SET_FIELD);
+  if (astron_support) { // Astron
+    packer.raw_pack_uint16(CLIENT_OBJECT_SET_FIELD);
+  } else { // OTP
+    packer.raw_pack_uint16(CLIENT_OBJECT_UPDATE_FIELD);
+  }
   packer.raw_pack_uint32(do_id);
   packer.raw_pack_uint16(_this->_number);
 
@@ -218,7 +222,11 @@ ai_format_update(DOID_TYPE do_id, CHANNEL_TYPE to_id, CHANNEL_TYPE from_id, PyOb
   packer.raw_pack_uint8(1);
   packer.RAW_PACK_CHANNEL(to_id);
   packer.RAW_PACK_CHANNEL(from_id);
-  packer.raw_pack_uint16(STATESERVER_OBJECT_SET_FIELD);
+  if (astron_support) { // Astron
+    packer.raw_pack_uint16(STATESERVER_OBJECT_SET_FIELD);
+  } else { // OTP
+    packer.raw_pack_uint16(STATESERVER_OBJECT_UPDATE_FIELD);
+  }
   packer.raw_pack_uint32(do_id);
   packer.raw_pack_uint16(_this->_number);
 

--- a/direct/src/dcparser/dcField_ext.h
+++ b/direct/src/dcparser/dcField_ext.h
@@ -22,6 +22,9 @@
 #include "dcField.h"
 #include "py_panda.h"
 
+#include "configVariableBool.h"
+extern ConfigVariableBool astron_support;
+
 /**
  * This class defines the extension methods for DCField, which are called
  * instead of any C++ methods with the same prototype.

--- a/direct/src/dcparser/dcmsgtypes.h
+++ b/direct/src/dcparser/dcmsgtypes.h
@@ -17,14 +17,27 @@
 // This file defines the server message types used within this module.  It
 // duplicates some symbols defined in MsgTypes.py and AIMsgTypes.py.
 
+// Astron Client messages:
 #define CLIENT_OBJECT_SET_FIELD                           120
 #define CLIENT_ENTER_OBJECT_REQUIRED                      142
 #define CLIENT_ENTER_OBJECT_REQUIRED_OTHER                143
 
+// OTP Client messages:
+#define CLIENT_OBJECT_UPDATE_FIELD                        24
+#define CLIENT_CREATE_OBJECT_REQUIRED                     34
+#define CLIENT_CREATE_OBJECT_REQUIRED_OTHER               35
+
+// Astron State Server messages:
 #define STATESERVER_CREATE_OBJECT_WITH_REQUIRED           2000
 #define STATESERVER_CREATE_OBJECT_WITH_REQUIRED_OTHER     2001
 #define STATESERVER_OBJECT_SET_FIELD                      2020
 
+// OTP State Server messages:
+#define STATESERVER_OBJECT_GENERATE_WITH_REQUIRED         2001
+#define STATESERVER_OBJECT_GENERATE_WITH_REQUIRED_OTHER   2003
+#define STATESERVER_OBJECT_UPDATE_FIELD                   2004
+
+// CMU messages:
 #define CLIENT_OBJECT_GENERATE_CMU                        9002
 
 #endif

--- a/direct/src/distributed/cConnectionRepository.cxx
+++ b/direct/src/distributed/cConnectionRepository.cxx
@@ -303,30 +303,61 @@ check_datagram() {
       return true;
     }
 
-    switch (_msg_type) {
+    // FIXME: This is despicable...
+    // There must be a better way of doing
+    // this...
+    if (astron_support) { // Astron
+      switch (_msg_type) {
 #ifdef HAVE_PYTHON
-    case CLIENT_OBJECT_SET_FIELD:
-    case STATESERVER_OBJECT_SET_FIELD:
-      if (_handle_c_updates) {
-        if (_has_owner_view) {
-          if (!handle_update_field_owner()) {
-            return false;
+      case CLIENT_OBJECT_SET_FIELD:
+      case STATESERVER_OBJECT_SET_FIELD:
+        if (_handle_c_updates) {
+          if (_has_owner_view) {
+            if (!handle_update_field_owner()) {
+              return false;
+            }
+          } else {
+            if (!handle_update_field()) {
+              return false;
+            }
           }
         } else {
-          if (!handle_update_field()) {
-            return false;
-          }
+          // Let the caller (Python) deal with this update.
+          return true;
         }
-      } else {
-        // Let the caller (Python) deal with this update.
-        return true;
-      }
-      break;
+        break;
 #endif  // HAVE_PYTHON
 
-    default:
-      // Some unknown message; let the caller deal with it.
-      return true;
+      default:
+        // Some unknown message; let the caller deal with it.
+        return true;
+      }
+    } else { // OTP
+      switch (_msg_type) {
+#ifdef HAVE_PYTHON
+      case CLIENT_OBJECT_UPDATE_FIELD:
+      case STATESERVER_OBJECT_UPDATE_FIELD:
+        if (_handle_c_updates) {
+          if (_has_owner_view) {
+            if (!handle_update_field_owner()) {
+              return false;
+            }
+          } else {
+            if (!handle_update_field()) {
+              return false;
+            }
+          }
+        } else {
+          // Let the caller (Python) deal with this update.
+          return true;
+        }
+        break;
+#endif  // HAVE_PYTHON
+
+      default:
+        // Some unknown message; let the caller deal with it.
+        return true;
+      }
     }
   }
 
@@ -906,11 +937,19 @@ describe_message(std::ostream &out, const string &prefix,
 
     packer.RAW_UNPACK_CHANNEL();  // msg_sender
     msg_type = packer.raw_unpack_uint16();
-    is_update = (msg_type == STATESERVER_OBJECT_SET_FIELD);
+    if (astron_support) {
+      is_update = (msg_type == STATESERVER_OBJECT_SET_FIELD);
+    } else {
+      is_update = (msg_type == STATESERVER_OBJECT_UPDATE_FIELD);
+    }
 
   } else {
     msg_type = packer.raw_unpack_uint16();
-    is_update = (msg_type == CLIENT_OBJECT_SET_FIELD);
+    if (astron_support) {
+      is_update = (msg_type == CLIENT_OBJECT_SET_FIELD);
+    } else {
+      is_update = (msg_type == CLIENT_OBJECT_UPDATE_FIELD);
+    }
   }
 
   if (!is_update) {

--- a/direct/src/distributed/cConnectionRepository.h
+++ b/direct/src/distributed/cConnectionRepository.h
@@ -26,6 +26,9 @@
 #include "reMutex.h"
 #include "reMutexHolder.h"
 
+#include "configVariableBool.h"
+extern ConfigVariableBool astron_support;
+
 #ifdef HAVE_NET
 #include "queuedConnectionManager.h"
 #include "connectionWriter.h"

--- a/direct/src/distributed/cDistributedSmoothNodeBase.cxx
+++ b/direct/src/distributed/cDistributedSmoothNodeBase.cxx
@@ -282,12 +282,20 @@ begin_send_update(DCPacker &packer, const std::string &field_name) {
     packer.RAW_PACK_CHANNEL(_do_id);
     packer.RAW_PACK_CHANNEL(_ai_id);
     // packer.raw_pack_uint8('A');
-    packer.raw_pack_uint16(STATESERVER_OBJECT_SET_FIELD);
+    if (astron_support) { // Astron
+      packer.raw_pack_uint16(STATESERVER_OBJECT_SET_FIELD);
+    } else { // OTP
+      packer.raw_pack_uint16(STATESERVER_OBJECT_UPDATE_FIELD);
+    }
     packer.raw_pack_uint32(_do_id);
     packer.raw_pack_uint16(field->get_number());
 
   } else {
-    packer.raw_pack_uint16(CLIENT_OBJECT_SET_FIELD);
+    if (astron_support) { // Astron
+      packer.raw_pack_uint16(CLIENT_OBJECT_SET_FIELD);
+    } else { // OTP
+      packer.raw_pack_uint16(CLIENT_OBJECT_UPDATE_FIELD);
+    }
     packer.raw_pack_uint32(_do_id);
     packer.raw_pack_uint16(field->get_number());
   }


### PR DESCRIPTION
This PR supports toggling between the new Astron message types and the old OTP message types by using the `astron-support` boolean configuration.

This is done mainly because of a failed and painful attempt of trying to send generate message with Python within the game's source, which lead me no choice but to add Astron/OTP toggling within Panda itself.

(if you have any idea of how to make `cConnectionRepository` look better, please let me know.)