### PR TITLE
AstronInternalRepository: Fix UnicodeDecodeError for fieldPacker

### DIFF
--- a/direct/src/distributed/AstronInternalRepository.py
+++ b/direct/src/distributed/AstronInternalRepository.py
@@ -522,7 +522,7 @@ class AstronInternalRepository(ConnectionRepository):
             dg.addServerHeader(doId, self.ourChannel, STATESERVER_OBJECT_SET_FIELDS)
             dg.addUint32(doId)
             dg.addUint16(fieldCount)
-            dg.appendData(fieldPacker.getString())
+            dg.appendData(fieldPacker.getBytes())
             self.send(dg)
             # Now slide it into the zone we expect to see it in (so it
             # generates onto us with all of the fields in place)


### PR DESCRIPTION
In python3 this is a byte not a string.

## Issue description
<!-- What is this change intended to accomplish?  What problem does it solve?
     If this change resolves a GitHub issue, include the issue number. -->
This change intends to fix errors with python3 and running sendActivate. The problem it solves are errors dealing with the fact the utf-8 codec is trying to decode a byte and can't.
## Solution description
<!-- Explain here how your PR solves the problem, what approach it takes. -->
It solves the problem by getting the bytes instead of the string 
## Checklist
I have done my best to ensure that…
* [ x] …I have familiarized myself with the CONTRIBUTING.md file
* [x ] …this change follows the coding style and design patterns of the codebase
* [ x] …I own the intellectual property rights to this code
* [ x] …the intent of this change is clearly explained
* [ x] …existing uses of the Panda3D API are not broken
* [ x] …the changed code is adequately covered by the test suite, where possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-toontown/panda3d/10)
<!-- Reviewable:end -->
